### PR TITLE
Add return type for function

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -5,7 +5,7 @@
  */
 import { fox, customfox } from "randomfox";
 
-function parse(custom: string) {
+function parse(custom: string): void {
     if (custom) {
         console.log(`
 ===============Foxes===============


### PR DESCRIPTION
I noticed that you have reported a false positive for `JS-0306: Missing explicit return and argument types` for this occurrence with the comment : 
> " Because this function doesn't need an callback. "

We must specify return types as `void` when it is not returning any value because not specifying type will take the whole point of using types in the first place.